### PR TITLE
C SDK: Document thread safety and fix js_cleanup

### DIFF
--- a/c/src/json_source_locator.c
+++ b/c/src/json_source_locator.c
@@ -11,6 +11,7 @@
 
 #include "json_structure/json_structure.h"
 #include "json_structure/types.h"
+#include "regex_utils.h"
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
@@ -395,6 +396,9 @@ void js_init_with_allocator(js_allocator_t alloc) {
 }
 
 void js_cleanup(void) {
+    /* Clear the regex cache before resetting allocator */
+    js_regex_cache_clear();
+    
     /* Reset to default allocator */
     js_allocator_t default_alloc = {NULL, NULL, NULL, NULL};
     js_set_allocator(default_alloc);


### PR DESCRIPTION
## Summary

Documents thread safety requirements for the C SDK and fixes js_cleanup() to properly clear the regex cache.

## Changes

- **README.md**: Add comprehensive Thread Safety section documenting:
  - Safe usage patterns (init once, cleanup once, thread-local results)
  - What is thread-safe (concurrent validation, regex cache)
  - What is NOT thread-safe (allocator changes during validation)
  - Multi-threaded usage example with pthreads

- **json_source_locator.c**: Fix js_cleanup() to call js_regex_cache_clear() before resetting the allocator

## Testing

- Existing tests continue to pass
- Thread safety tests should be added (tracked in issue)

Fixes #23