### PR TITLE
fix: restore sibling errors on union branch success (Python, PHP)

### DIFF
--- a/php/src/JsonStructure/InstanceValidator.php
+++ b/php/src/JsonStructure/InstanceValidator.php
@@ -185,14 +185,15 @@ class InstanceValidator
                 $backup = $this->errors;
                 $this->errors = [];
                 $this->validateInstance($instance, ['type' => $t], $path, $depth + 1);
-                if (count($this->errors) === 0) {
+                $branchErrors = $this->errors;
+                $this->errors = $backup;
+                if (count($branchErrors) === 0) {
                     $unionValid = true;
                     break;
                 }
-                foreach ($this->errors as $e) {
+                foreach ($branchErrors as $e) {
                     $unionErrors[] = (string) $e;
                 }
-                $this->errors = $backup;
             }
             if (!$unionValid) {
                 $this->addError("Instance at {$path} does not match any type in union: " . implode(', ', $unionErrors), $path);

--- a/php/tests/InstanceValidatorTest.php
+++ b/php/tests/InstanceValidatorTest.php
@@ -765,6 +765,35 @@ class InstanceValidatorTest extends TestCase
         $this->assertGreaterThan(0, count($errors));
     }
 
+    public function testUnionSuccessDoesNotWipeSiblingErrors(): void
+    {
+        $schema = [
+            '$id' => 'https://example.com/union-sibling.struct.json',
+            'name' => 'UnionSiblingErrorSchema',
+            'type' => 'object',
+            'properties' => [
+                'a' => ['type' => 'int64'],
+                'b' => ['type' => 'int64'],
+                'lat' => ['type' => ['double', 'null']],
+            ],
+            'required' => ['a', 'b'],
+        ];
+
+        $validator = new InstanceValidator($schema, extended: true);
+        $errors = $validator->validate(['a' => 1, 'b' => 2, 'lat' => 59.9]);
+        // a and b are numbers but int64 requires string representation
+        $this->assertGreaterThanOrEqual(2, count($errors));
+        $errorMessages = array_map(fn($e) => (string)$e, $errors);
+        $hasA = false;
+        $hasB = false;
+        foreach ($errorMessages as $msg) {
+            if (str_contains($msg, '#/a')) $hasA = true;
+            if (str_contains($msg, '#/b')) $hasB = true;
+        }
+        $this->assertTrue($hasA, 'Expected error for property a');
+        $this->assertTrue($hasB, 'Expected error for property b');
+    }
+
     public function testRefInType(): void
     {
         $schema = [

--- a/python/src/json_structure/instance_validator.py
+++ b/python/src/json_structure/instance_validator.py
@@ -247,12 +247,13 @@ class JSONStructureInstanceValidator:
                 backup = list(self.errors)
                 self.errors = []
                 self.validate_instance(instance, {"type": t}, path)
-                if not self.errors:
+                branch_errors = self.errors
+                self.errors = backup
+                if not branch_errors:
                     union_valid = True
                     break
                 else:
-                    union_errors.extend(self.errors)
-                self.errors = backup
+                    union_errors.extend(branch_errors)
             if not union_valid:
                 self.errors.append(f"Instance at {path} does not match any type in union: {union_errors}")
             return self.errors

--- a/python/tests/test_instance_validator.py
+++ b/python/tests/test_instance_validator.py
@@ -901,6 +901,28 @@ def test_union_invalid():
     errors = validator.validate_instance(True)
     assert any("does not match any type in union" in err for err in errors)
 
+
+def test_union_success_does_not_wipe_sibling_errors():
+    """Regression: a successful union branch must not discard errors from sibling properties."""
+    schema = {
+        "$schema": "https://json-structure.org/meta/extended/v0/#",
+        "$id": "https://test.example.com/schema/unionSiblingErrors",
+        "name": "unionSiblingErrorSchema",
+        "type": "object",
+        "properties": {
+            "a": {"type": "int64"},
+            "b": {"type": "int64"},
+            "lat": {"type": ["double", "null"]}
+        },
+        "required": ["a", "b"]
+    }
+    validator = JSONStructureInstanceValidator(schema, extended=True)
+    errors = validator.validate_instance({"a": 1, "b": 2, "lat": 59.9})
+    # a and b are numbers but int64 requires string representation
+    assert len(errors) >= 2
+    assert any("#/a" in err for err in errors)
+    assert any("#/b" in err for err in errors)
+
 # -------------------------------------------------------------------
 # const and enum Tests
 # -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #160 — `InstanceValidator` union-type branch wiped accumulated sibling errors when a union member validated successfully.

## Root Cause

In both the Python and PHP implementations, the union validation loop set `self.errors = []` before trying each branch type. On a successful branch match, the code broke out of the loop **without restoring** the backup, leaving the error list empty and discarding all previously collected violations for sibling properties.

## Fix

Always capture branch errors in a local variable and restore the backup before checking success — both on match and non-match paths. This ensures sibling errors are preserved regardless of union validation outcome.

## Other SDKs

Checked all 11 SDK implementations:
- **Rust, Go, TypeScript, Swift** — already correct (use separate temp result/context)
- **C, Perl** — use simple type-match functions without shared error accumulation
- **Java, C#** — don't handle type unions at the instance validation level

## Tests

Added regression tests in both Python and PHP covering the exact reproducer from the issue (object with failing `int64` siblings + succeeding `["double", "null"]` union property).
