### PR TITLE
Fix Rust validation conformance and release 0.8.1

### DIFF
--- a/.github/workflows/jstruct-cli.yml
+++ b/.github/workflows/jstruct-cli.yml
@@ -64,6 +64,18 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Verify release tag matches Cargo version
+        if: startsWith(github.ref, 'refs/tags/jstruct-v')
+        working-directory: rust
+        shell: bash
+        run: |
+          EXPECTED_VERSION=${GITHUB_REF#refs/tags/jstruct-v}
+          CARGO_VERSION=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -1)
+          if [[ "$CARGO_VERSION" != "$EXPECTED_VERSION" ]]; then
+            echo "Cargo version $CARGO_VERSION does not match release tag $EXPECTED_VERSION"
+            exit 1
+          fi
+
       - name: Install cross-compilation tools (Linux ARM64)
         if: matrix.cross && matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
@@ -158,7 +170,17 @@ jobs:
         run: chmod +x bin/${{ matrix.artifact }}
 
       - name: Test --version
-        run: bin/${{ matrix.artifact }} --version
+        shell: bash
+        run: |
+          ACTUAL=$(bin/${{ matrix.artifact }} --version)
+          echo "$ACTUAL"
+          if [[ "$GITHUB_REF" == refs/tags/jstruct-v* ]]; then
+            EXPECTED_VERSION=${GITHUB_REF#refs/tags/jstruct-v}
+            if [[ "$ACTUAL" != "jstruct $EXPECTED_VERSION" ]]; then
+              echo "Embedded version '$ACTUAL' does not match release tag '$EXPECTED_VERSION'"
+              exit 1
+            fi
+          fi
 
       - name: Test --help
         run: bin/${{ matrix.artifact }} --help

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "json-structure"
-version = "0.1.0"
+version = "0.8.1"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "json-structure"
-version = "0.1.0"
+version = "0.8.1"
 edition = "2021"
 authors = ["JSON Structure Contributors"]
 license = "MIT"

--- a/rust/src/error_codes.rs
+++ b/rust/src/error_codes.rs
@@ -254,6 +254,14 @@ pub enum InstanceErrorCode {
     InstancePatternPropertyMismatch,
     InstancePropertyNameInvalid,
 
+    // Root document metadata errors
+    InstanceSchemaMissing,
+    InstanceSchemaInvalid,
+    InstanceSchemaMismatch,
+    InstanceUsesInvalid,
+    InstanceUsesUnknown,
+    InstanceUsesConflict,
+
     // Array errors
     InstanceArrayExpected,
     InstanceArrayTooShort,
@@ -363,6 +371,12 @@ impl InstanceErrorCode {
             Self::InstanceDependentRequiredMissing => "INSTANCE_DEPENDENT_REQUIRED_MISSING",
             Self::InstancePatternPropertyMismatch => "INSTANCE_PATTERN_PROPERTY_MISMATCH",
             Self::InstancePropertyNameInvalid => "INSTANCE_PROPERTY_NAME_INVALID",
+            Self::InstanceSchemaMissing => "INSTANCE_SCHEMA_MISSING",
+            Self::InstanceSchemaInvalid => "INSTANCE_SCHEMA_INVALID",
+            Self::InstanceSchemaMismatch => "INSTANCE_SCHEMA_MISMATCH",
+            Self::InstanceUsesInvalid => "INSTANCE_USES_INVALID",
+            Self::InstanceUsesUnknown => "INSTANCE_USES_UNKNOWN",
+            Self::InstanceUsesConflict => "INSTANCE_USES_CONFLICT",
             Self::InstanceArrayExpected => "INSTANCE_ARRAY_EXPECTED",
             Self::InstanceArrayTooShort => "INSTANCE_ARRAY_TOO_SHORT",
             Self::InstanceArrayTooLong => "INSTANCE_ARRAY_TOO_LONG",

--- a/rust/src/instance_validator.rs
+++ b/rust/src/instance_validator.rs
@@ -91,8 +91,23 @@ impl InstanceValidator {
                 } else {
                     schema
                 };
-                
-                self.validate_instance(&instance, effective_schema, schema, &mut result, "", &locator, 0);
+
+                let (effective_instance, effective_root_schema) = self.prepare_root_instance(
+                    &instance,
+                    effective_schema,
+                    schema,
+                    &mut result,
+                    &locator,
+                );
+                self.validate_instance(
+                    &effective_instance,
+                    &effective_root_schema,
+                    schema,
+                    &mut result,
+                    "",
+                    &locator,
+                    0,
+                );
             }
             Err(e) => {
                 result.add_error(ValidationError::instance_error(
@@ -105,6 +120,203 @@ impl InstanceValidator {
         }
 
         result
+    }
+
+    fn prepare_root_instance(
+        &self,
+        instance: &Value,
+        effective_schema: &Value,
+        root_schema: &Value,
+        result: &mut ValidationResult,
+        locator: &JsonSourceLocator,
+    ) -> (Value, Value) {
+        let Some(instance_obj) = instance.as_object() else {
+            return (instance.clone(), effective_schema.clone());
+        };
+
+        let mut prepared = instance_obj.clone();
+        let mut prepared_schema = effective_schema.clone();
+        let schema_id = root_schema.get("$id").and_then(Value::as_str);
+        let expects_object = effective_schema.get("type").and_then(Value::as_str) == Some("object");
+
+        match instance_obj.get("$schema") {
+            Some(Value::String(instance_schema)) => {
+                if url::Url::parse(instance_schema).is_err() {
+                    result.add_error(ValidationError::instance_error(
+                        InstanceErrorCode::InstanceSchemaInvalid,
+                        "$schema must be an absolute URI",
+                        "/$schema",
+                        locator.get_location("/$schema"),
+                    ));
+                } else if let Some(expected) = schema_id {
+                    if instance_schema != expected {
+                        result.add_error(ValidationError::instance_error(
+                            InstanceErrorCode::InstanceSchemaMismatch,
+                            format!("$schema '{}' does not match schema $id '{}'", instance_schema, expected),
+                            "/$schema",
+                            locator.get_location("/$schema"),
+                        ));
+                    }
+                }
+            }
+            Some(_) => result.add_error(ValidationError::instance_error(
+                InstanceErrorCode::InstanceSchemaInvalid,
+                "$schema must be a string containing an absolute URI",
+                "/$schema",
+                locator.get_location("/$schema"),
+            )),
+            None if expects_object && schema_id.is_some() => {
+                result.add_error(ValidationError::instance_error(
+                    InstanceErrorCode::InstanceSchemaMissing,
+                    "Root JSON document must declare $schema",
+                    "",
+                    locator.get_location(""),
+                ));
+            }
+            None => {}
+        }
+
+        prepared.remove("$schema");
+        if let Some(uses) = instance_obj.get("$uses") {
+            self.apply_root_uses(uses, &mut prepared_schema, root_schema, result, locator);
+            prepared.remove("$uses");
+        }
+
+        (Value::Object(prepared), prepared_schema)
+    }
+
+    fn apply_root_uses(
+        &self,
+        uses: &Value,
+        effective_schema: &mut Value,
+        root_schema: &Value,
+        result: &mut ValidationResult,
+        locator: &JsonSourceLocator,
+    ) {
+        let Some(use_names) = uses.as_array() else {
+            result.add_error(ValidationError::instance_error(
+                InstanceErrorCode::InstanceUsesInvalid,
+                "$uses must be an array of unique add-in names",
+                "/$uses",
+                locator.get_location("/$uses"),
+            ));
+            return;
+        };
+        let offers = root_schema.get("$offers").and_then(Value::as_object);
+        let mut seen = std::collections::HashSet::new();
+
+        for (index, use_name) in use_names.iter().enumerate() {
+            let use_path = format!("/$uses/{}", index);
+            let Some(use_name) = use_name.as_str() else {
+                result.add_error(ValidationError::instance_error(
+                    InstanceErrorCode::InstanceUsesInvalid,
+                    "$uses entries must be strings",
+                    &use_path,
+                    locator.get_location(&use_path),
+                ));
+                continue;
+            };
+            if !seen.insert(use_name) {
+                result.add_error(ValidationError::instance_error(
+                    InstanceErrorCode::InstanceUsesInvalid,
+                    format!("Duplicate add-in name in $uses: {}", use_name),
+                    &use_path,
+                    locator.get_location(&use_path),
+                ));
+                continue;
+            }
+
+            let Some(offer) = offers.and_then(|available| available.get(use_name)) else {
+                result.add_error(ValidationError::instance_error(
+                    InstanceErrorCode::InstanceUsesUnknown,
+                    format!("Add-in '{}' is not advertised by $offers", use_name),
+                    &use_path,
+                    locator.get_location(&use_path),
+                ));
+                continue;
+            };
+
+            let refs: Vec<&str> = match offer {
+                Value::String(reference) => vec![reference],
+                Value::Array(references) => references.iter().filter_map(Value::as_str).collect(),
+                _ => {
+                    result.add_error(ValidationError::instance_error(
+                        InstanceErrorCode::InstanceUsesInvalid,
+                        format!("Offer '{}' must contain a JSON Pointer or an array of JSON Pointers", use_name),
+                        &use_path,
+                        locator.get_location(&use_path),
+                    ));
+                    continue;
+                }
+            };
+
+            for reference in refs {
+                let Some(addin) = self.resolve_ref(reference, root_schema).and_then(Value::as_object) else {
+                    result.add_error(ValidationError::instance_error(
+                        InstanceErrorCode::InstanceUsesInvalid,
+                        format!("Add-in '{}' reference could not be resolved: {}", use_name, reference),
+                        &use_path,
+                        locator.get_location(&use_path),
+                    ));
+                    continue;
+                };
+                self.merge_addin(use_name, addin, effective_schema, result, &use_path, locator);
+            }
+        }
+    }
+
+    fn merge_addin(
+        &self,
+        use_name: &str,
+        addin: &serde_json::Map<String, Value>,
+        effective_schema: &mut Value,
+        result: &mut ValidationResult,
+        path: &str,
+        locator: &JsonSourceLocator,
+    ) {
+        let Some(effective_obj) = effective_schema.as_object_mut() else {
+            result.add_error(ValidationError::instance_error(
+                InstanceErrorCode::InstanceUsesInvalid,
+                format!("Add-in '{}' requires an object root schema", use_name),
+                path,
+                locator.get_location(path),
+            ));
+            return;
+        };
+        let properties = effective_obj
+            .entry("properties".to_string())
+            .or_insert_with(|| Value::Object(serde_json::Map::new()));
+        let Some(properties) = properties.as_object_mut() else {
+            return;
+        };
+
+        if let Some(addin_properties) = addin.get("properties").and_then(Value::as_object) {
+            for (name, property_schema) in addin_properties {
+                if properties.contains_key(name) {
+                    result.add_error(ValidationError::instance_error(
+                        InstanceErrorCode::InstanceUsesConflict,
+                        format!("Add-in '{}' conflicts on property '{}'", use_name, name),
+                        path,
+                        locator.get_location(path),
+                    ));
+                } else {
+                    properties.insert(name.clone(), property_schema.clone());
+                }
+            }
+        }
+
+        if let Some(addin_required) = addin.get("required").and_then(Value::as_array) {
+            let required = effective_obj
+                .entry("required".to_string())
+                .or_insert_with(|| Value::Array(Vec::new()));
+            if let Some(required) = required.as_array_mut() {
+                for name in addin_required {
+                    if !required.contains(name) {
+                        required.push(name.clone());
+                    }
+                }
+            }
+        }
     }
 
     /// Validates an instance value against a schema.
@@ -354,7 +566,6 @@ impl InstanceValidator {
         
         // Build merged schema
         let mut merged = schema_obj.clone();
-        merged.remove("$extends");
         if !merged_properties.is_empty() {
             merged.insert("properties".to_string(), Value::Object(merged_properties));
         }
@@ -2138,10 +2349,20 @@ impl InstanceValidator {
             None => return,
         };
 
-        let selector = schema_obj.get("selector").and_then(Value::as_str);
+        if schema_obj.contains_key("$extends") {
+            let selector_prop = match schema_obj.get("selector").and_then(Value::as_str) {
+                Some(selector) => selector,
+                None => {
+                    result.add_error(ValidationError::instance_error(
+                        InstanceErrorCode::InstanceChoiceSelectorMissing,
+                        "Inline choice schema must declare a selector",
+                        path,
+                        locator.get_location(path),
+                    ));
+                    return;
+                }
+            };
 
-        if let Some(selector_prop) = selector {
-            // Discriminated choice
             let obj = match instance {
                 Value::Object(o) => o,
                 _ => {
@@ -2178,7 +2399,45 @@ impl InstanceValidator {
             };
 
             if let Some(choice_schema) = choices.get(selector_value) {
-                self.validate_instance(instance, choice_schema, root_schema, result, path, locator, depth + 1);
+                let Some(mut selected_schema) = self.materialize_choice_schema(choice_schema, root_schema) else {
+                    result.add_error(ValidationError::instance_error(
+                        InstanceErrorCode::InstanceChoiceNoMatch,
+                        format!("Inline choice '{}' does not resolve to an object schema", selector_value),
+                        path,
+                        locator.get_location(path),
+                    ));
+                    return;
+                };
+
+                let properties = selected_schema
+                    .entry("properties".to_string())
+                    .or_insert_with(|| Value::Object(serde_json::Map::new()));
+                let Some(properties) = properties.as_object_mut() else {
+                    result.add_error(ValidationError::instance_error(
+                        InstanceErrorCode::InstanceChoiceNoMatch,
+                        format!("Inline choice '{}' has invalid object properties", selector_value),
+                        path,
+                        locator.get_location(path),
+                    ));
+                    return;
+                };
+
+                let selector_schema = properties
+                    .entry(selector_prop.to_string())
+                    .or_insert_with(|| serde_json::json!({ "type": "string" }));
+                if let Some(selector_schema) = selector_schema.as_object_mut() {
+                    selector_schema.insert("const".to_string(), Value::String(selector_value.to_string()));
+                }
+
+                self.validate_instance(
+                    instance,
+                    &Value::Object(selected_schema),
+                    root_schema,
+                    result,
+                    path,
+                    locator,
+                    depth + 1,
+                );
             } else {
                 result.add_error(ValidationError::instance_error(
                     InstanceErrorCode::InstanceChoiceUnknown,
@@ -2240,6 +2499,37 @@ impl InstanceValidator {
                     locator.get_location(path),
                 ));
             }
+        }
+    }
+
+    fn materialize_choice_schema(
+        &self,
+        choice_schema: &Value,
+        root_schema: &Value,
+    ) -> Option<serde_json::Map<String, Value>> {
+        let resolved = if let Some(ref_str) = choice_schema.get("$ref").and_then(Value::as_str) {
+            self.resolve_ref(ref_str, root_schema)?
+        } else if let Some(ref_str) = choice_schema
+            .get("type")
+            .and_then(Value::as_object)
+            .and_then(|type_obj| type_obj.get("$ref"))
+            .and_then(Value::as_str)
+        {
+            self.resolve_ref(ref_str, root_schema)?
+        } else {
+            choice_schema
+        };
+
+        let schema_obj = resolved.as_object()?;
+        let materialized = if schema_obj.contains_key("$extends") {
+            self.merge_extends(schema_obj, root_schema)?
+        } else {
+            schema_obj.clone()
+        };
+
+        match materialized.get("type").and_then(Value::as_str) {
+            Some("object") => Some(materialized),
+            _ => None,
         }
     }
 
@@ -2407,7 +2697,10 @@ mod tests {
             },
             "required": ["name"]
         });
-        let result = validator.validate(r#"{"name": "test"}"#, &schema);
+        let result = validator.validate(
+            r#"{"$schema":"https://example.com/test","name":"test"}"#,
+            &schema,
+        );
         assert!(result.is_valid());
     }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -39,7 +39,8 @@
 //!
 //! // Validate an instance
 //! let schema: serde_json::Value = serde_json::from_str(schema_json).unwrap();
-//! let instance_json = r#"{"name": "Alice", "age": 30}"#;
+//! let instance_json =
+//!     r#"{"$schema": "https://example.com/person", "name": "Alice", "age": 30}"#;
 //!
 //! let instance_validator = InstanceValidator::new();
 //! let instance_result = instance_validator.validate(instance_json, &schema);

--- a/rust/src/schema_validator.rs
+++ b/rust/src/schema_validator.rs
@@ -256,6 +256,7 @@ impl SchemaValidator {
         if let Some(extends_val) = obj.get("$extends") {
             self.validate_extends(
                 extends_val,
+                obj,
                 root_schema,
                 locator,
                 result,
@@ -271,6 +272,25 @@ impl SchemaValidator {
         }
 
         let type_name = obj.get("type").and_then(Value::as_str);
+        if obj.get("abstract") == Some(&Value::Bool(true)) {
+            if !matches!(type_name, Some("object" | "tuple")) {
+                result.add_error(ValidationError::schema_error(
+                    SchemaErrorCode::SchemaConstraintTypeMismatch,
+                    "abstract is only valid on object and tuple schemas",
+                    path,
+                    locator.get_location(path),
+                ));
+            }
+            if obj.contains_key("additionalProperties") {
+                let additional_path = format!("{}/additionalProperties", path);
+                result.add_error(ValidationError::schema_error(
+                    SchemaErrorCode::SchemaAdditionalPropertiesInvalid,
+                    "Abstract types implicitly allow additional properties and must not declare additionalProperties",
+                    &additional_path,
+                    locator.get_location(&additional_path),
+                ));
+            }
+        }
         self.validate_units_keywords(obj, locator, result, path, type_name, &enabled_extensions);
         self.validate_relations_keywords(
             obj,
@@ -472,14 +492,23 @@ impl SchemaValidator {
     ) {
         let offers_path = format!("{}/$offers", path);
         match offers {
-            Value::Array(arr) => {
-                for (i, ext) in arr.iter().enumerate() {
-                    if !ext.is_string() {
+            Value::Object(offers) => {
+                for (name, offer) in offers {
+                    let offer_path = format!("{}/{}", offers_path, name);
+                    let valid = match offer {
+                        Value::String(reference) => reference.starts_with("#/definitions/"),
+                        Value::Array(references) => !references.is_empty()
+                            && references.iter().all(|reference| {
+                                reference.as_str().is_some_and(|value| value.starts_with("#/definitions/"))
+                            }),
+                        _ => false,
+                    };
+                    if !valid {
                         result.add_error(ValidationError::schema_error(
                             SchemaErrorCode::SchemaOffersInvalidExtension,
-                            "Extension name must be a string",
-                            &format!("{}/{}", offers_path, i),
-                            locator.get_location(&format!("{}/{}", offers_path, i)),
+                            "Each $offers entry must be a JSON Pointer or non-empty array of JSON Pointers",
+                            &offer_path,
+                            locator.get_location(&offer_path),
                         ));
                     }
                 }
@@ -487,7 +516,7 @@ impl SchemaValidator {
             _ => {
                 result.add_error(ValidationError::schema_error(
                     SchemaErrorCode::SchemaOffersNotArray,
-                    "$offers must be an array",
+                    "$offers must be an object mapping add-in names to JSON Pointers",
                     &offers_path,
                     locator.get_location(&offers_path),
                 ));
@@ -1451,15 +1480,104 @@ impl SchemaValidator {
             }
         }
 
-        // Validate selector if present
+        let is_inline = obj.contains_key("$extends");
+        if is_inline {
+            if !obj.contains_key("selector") {
+                result.add_error(ValidationError::schema_error(
+                    SchemaErrorCode::SchemaChoiceInvalid,
+                    "Inline choice with $extends must declare selector",
+                    path,
+                    locator.get_location(path),
+                ));
+            }
+        } else if obj.contains_key("selector") {
+            let selector_path = format!("{}/selector", path);
+            result.add_error(ValidationError::schema_error(
+                SchemaErrorCode::SchemaChoiceInvalid,
+                "Tagged choice must not declare selector; $extends selects the inline representation",
+                &selector_path,
+                locator.get_location(&selector_path),
+            ));
+        }
+
         if let Some(selector) = obj.get("selector") {
             let selector_path = format!("{}/selector", path);
-            if !selector.is_string() {
+            if selector.as_str().is_none_or(str::is_empty) {
                 result.add_error(ValidationError::schema_error(
                     SchemaErrorCode::SchemaSelectorNotString,
-                    "selector must be a string",
+                    "selector must be a non-empty string",
                     &selector_path,
                     locator.get_location(&selector_path),
+                ));
+            }
+        }
+
+        if is_inline {
+            self.validate_inline_choice_alternatives(obj, root_schema, locator, result, path);
+        }
+    }
+
+    fn validate_inline_choice_alternatives(
+        &self,
+        obj: &serde_json::Map<String, Value>,
+        root_schema: &Value,
+        locator: &JsonSourceLocator,
+        result: &mut ValidationResult,
+        path: &str,
+    ) {
+        let base_refs: HashSet<&str> = match obj.get("$extends") {
+            Some(Value::String(reference)) => std::iter::once(reference.as_str()).collect(),
+            Some(Value::Array(references)) => references.iter().filter_map(Value::as_str).collect(),
+            _ => return,
+        };
+        let Some(choices) = obj.get("choices").and_then(Value::as_object) else {
+            return;
+        };
+
+        for (name, choice) in choices {
+            let choice_path = format!("{}/choices/{}", path, name);
+            let resolved = if let Some(reference) = choice.get("$ref").and_then(Value::as_str) {
+                self.resolve_ref(reference, root_schema)
+            } else if let Some(reference) = choice
+                .get("type")
+                .and_then(Value::as_object)
+                .and_then(|type_obj| type_obj.get("$ref"))
+                .and_then(Value::as_str)
+            {
+                self.resolve_ref(reference, root_schema)
+            } else {
+                Some(choice)
+            };
+            let Some(choice_obj) = resolved.and_then(Value::as_object) else {
+                result.add_error(ValidationError::schema_error(
+                    SchemaErrorCode::SchemaChoiceInvalid,
+                    "Inline choice alternatives must resolve to object schemas",
+                    &choice_path,
+                    locator.get_location(&choice_path),
+                ));
+                continue;
+            };
+            if choice_obj.get("type").and_then(Value::as_str) != Some("object") {
+                result.add_error(ValidationError::schema_error(
+                    SchemaErrorCode::SchemaChoiceInvalid,
+                    "Inline choice alternatives must resolve to object schemas",
+                    &choice_path,
+                    locator.get_location(&choice_path),
+                ));
+                continue;
+            }
+
+            let choice_bases: HashSet<&str> = match choice_obj.get("$extends") {
+                Some(Value::String(reference)) => std::iter::once(reference.as_str()).collect(),
+                Some(Value::Array(references)) => references.iter().filter_map(Value::as_str).collect(),
+                _ => HashSet::new(),
+            };
+            if !base_refs.iter().all(|base| choice_bases.contains(base)) {
+                result.add_error(ValidationError::schema_error(
+                    SchemaErrorCode::SchemaChoiceInvalid,
+                    "Every inline choice alternative must extend the declared common base",
+                    &choice_path,
+                    locator.get_location(&choice_path),
                 ));
             }
         }
@@ -1850,6 +1968,7 @@ impl SchemaValidator {
     fn validate_extends(
         &self,
         extends_val: &Value,
+        extending_schema: &serde_json::Map<String, Value>,
         root_schema: &Value,
         locator: &JsonSourceLocator,
         result: &mut ValidationResult,
@@ -1936,13 +2055,23 @@ impl SchemaValidator {
             if ref_str.starts_with("#/definitions/") {
                 if let Some(resolved) = self.resolve_ref(&ref_str, root_schema) {
                     let resolved_type = resolved.get("type").and_then(Value::as_str);
-                    if resolved_type.is_some() && !matches!(resolved_type, Some("object" | "tuple" | "map" | "array" | "set" | "choice")) {
+                    let extending_type = extending_schema.get("type").and_then(Value::as_str);
+                    let expected_type = if extending_type == Some("choice") {
+                        Some("object")
+                    } else {
+                        extending_type
+                    };
+                    if !matches!(extending_type, Some("object" | "tuple" | "choice")) {
                         result.add_error(ValidationError::schema_error(
                             SchemaErrorCode::SchemaConstraintTypeMismatch,
-                            format!(
-                                "$extends target '{}' must not resolve to a primitive type",
-                                ref_str
-                            ),
+                            "$extends is only valid on object, tuple, and inline choice schemas",
+                            &ref_path,
+                            locator.get_location(&ref_path),
+                        ));
+                    } else if resolved_type != expected_type || resolved.get("abstract") != Some(&Value::Bool(true)) {
+                        result.add_error(ValidationError::schema_error(
+                            SchemaErrorCode::SchemaConstraintTypeMismatch,
+                            format!("$extends target '{}' must resolve to an abstract {} schema", ref_str, expected_type.unwrap_or("object")),
                             &ref_path,
                             locator.get_location(&ref_path),
                         ));
@@ -2438,7 +2567,6 @@ mod tests {
             "$id": "https://example.com/schema",
             "name": "TestSchema",
             "type": "choice",
-            "selector": "kind",
             "choices": {
                 "text": { "type": "string" },
                 "number": { "type": "int32" }
@@ -2540,8 +2668,7 @@ mod tests {
         let result = validator.validate(schema);
         assert!(result.all_errors().iter().any(|err| {
             err.code == SchemaErrorCode::SchemaConstraintTypeMismatch.as_str()
-                && err.message
-                    == "$extends target '#/definitions/Base' must not resolve to a primitive type"
+                && err.message.contains("must resolve to an abstract object schema")
         }));
     }
 

--- a/rust/tests/cli_tests.rs
+++ b/rust/tests/cli_tests.rs
@@ -47,12 +47,12 @@ fn create_test_files() -> TempDir {
     // Valid instance
     let valid_instance_path = dir.path().join("valid.json");
     let mut f = File::create(&valid_instance_path).unwrap();
-    writeln!(f, r#"{{"name": "Alice", "age": 30}}"#).unwrap();
+    writeln!(f, r#"{{"$schema": "https://example.com/test", "name": "Alice", "age": 30}}"#).unwrap();
     
     // Invalid instance
     let invalid_instance_path = dir.path().join("invalid.json");
     let mut f = File::create(&invalid_instance_path).unwrap();
-    writeln!(f, r#"{{"age": "not a number"}}"#).unwrap();
+    writeln!(f, r#"{{"$schema": "https://example.com/test", "age": "not a number"}}"#).unwrap();
     
     // Invalid JSON
     let bad_json_path = dir.path().join("bad.json");
@@ -68,7 +68,10 @@ fn test_version() {
         .arg("--version")
         .assert()
         .success()
-        .stdout(predicate::str::contains("jstruct"));
+        .stdout(predicate::str::contains(format!(
+            "jstruct {}",
+            env!("CARGO_PKG_VERSION")
+        )));
 }
 
 #[test]

--- a/rust/tests/instance_validator_tests.rs
+++ b/rust/tests/instance_validator_tests.rs
@@ -687,29 +687,67 @@ fn test_tuple_wrong_type() {
 fn test_choice_with_selector() {
     let schema = json!({
         "type": "choice",
+        "$extends": "#/definitions/Base",
         "selector": "type",
+        "definitions": {
+            "Base": {
+                "abstract": true,
+                "type": "object",
+                "properties": { "id": { "type": "string" } },
+                "required": ["id"]
+            },
+            "Card": {
+                "type": "object",
+                "$extends": "#/definitions/Base",
+                "properties": { "cardNumber": { "type": "string" } },
+                "additionalProperties": false
+            },
+            "Cash": {
+                "type": "object",
+                "$extends": "#/definitions/Base",
+                "properties": { "amount": { "type": "decimal" } },
+                "additionalProperties": false
+            }
+        },
         "choices": {
-            "card": {"type": "object", "properties": {"cardNumber": {"type": "string"}}},
-            "cash": {"type": "object", "properties": {"amount": {"type": "decimal"}}}
+            "card": { "type": { "$ref": "#/definitions/Card" } },
+            "cash": { "type": { "$ref": "#/definitions/Cash" } }
         }
     });
     let validator = InstanceValidator::new();
     
-    let result = validator.validate(r#"{"type": "card", "cardNumber": "1234"}"#, &schema);
+    let result = validator.validate(r#"{"type":"card","id":"1","cardNumber":"1234"}"#, &schema);
     assert!(result.is_valid(), "Valid choice with selector should pass");
     
-    let result = validator.validate(r#"{"type": "cash", "amount": 100}"#, &schema);
+    let result = validator.validate(r#"{"type":"cash","id":"1","amount":100}"#, &schema);
     assert!(result.is_valid(), "Valid cash choice should pass");
+
+    let missing_base = validator.validate(r#"{"type":"card","cardNumber":"1234"}"#, &schema);
+    assert!(!missing_base.is_valid(), "Inherited required properties must be enforced");
+
+    let unrelated = validator.validate(
+        r#"{"type":"card","id":"1","cardNumber":"1234","extra":true}"#,
+        &schema,
+    );
+    assert!(!unrelated.is_valid(), "Closed choice must reject unrelated properties");
 }
 
 #[test]
 fn test_choice_unknown_selector_value() {
     let schema = json!({
         "type": "choice",
+        "$extends": "#/definitions/Base",
         "selector": "type",
+        "definitions": {
+            "Base": {
+                "abstract": true,
+                "type": "object",
+                "properties": { "id": { "type": "string" } }
+            }
+        },
         "choices": {
-            "card": {"type": "object", "properties": {"cardNumber": {"type": "string"}}},
-            "cash": {"type": "object", "properties": {"amount": {"type": "decimal"}}}
+            "card": {"type": "object", "$extends": "#/definitions/Base", "properties": {"cardNumber": {"type": "string"}}},
+            "cash": {"type": "object", "$extends": "#/definitions/Base", "properties": {"amount": {"type": "decimal"}}}
         }
     });
     let validator = InstanceValidator::new();
@@ -1010,6 +1048,103 @@ fn test_format_not_applied_without_extended() {
 // =============================================================================
 // $extends Validation
 // =============================================================================
+
+#[test]
+fn test_root_schema_metadata_is_not_an_additional_property() {
+    let schema = json!({
+        "$id": "https://example.com/person",
+        "type": "object",
+        "properties": {
+            "name": { "type": "string" }
+        },
+        "required": ["name"],
+        "additionalProperties": false
+    });
+    let validator = InstanceValidator::new();
+
+    let valid = validator.validate(
+        r#"{"$schema":"https://example.com/person","name":"Ada"}"#,
+        &schema,
+    );
+    assert!(valid.is_valid(), "$schema must not be treated as application data");
+
+    let missing = validator.validate(r#"{"name":"Ada"}"#, &schema);
+    assert!(!missing.is_valid(), "A root JSON document must declare $schema");
+
+    let mismatch = validator.validate(
+        r#"{"$schema":"https://example.com/other","name":"Ada"}"#,
+        &schema,
+    );
+    assert!(!mismatch.is_valid(), "$schema must match the supplied schema $id");
+}
+
+#[test]
+fn test_nested_schema_remains_an_application_property() {
+    let schema = json!({
+        "$id": "https://example.com/envelope",
+        "type": "object",
+        "properties": {
+            "nested": {
+                "type": "object",
+                "properties": { "value": { "type": "string" } },
+                "additionalProperties": false
+            }
+        },
+        "additionalProperties": false
+    });
+    let validator = InstanceValidator::new();
+
+    let result = validator.validate(
+        r#"{"$schema":"https://example.com/envelope","nested":{"$schema":"https://example.com/nested","value":"x"}}"#,
+        &schema,
+    );
+    assert!(!result.is_valid(), "Nested $schema must not receive root treatment");
+}
+
+#[test]
+fn test_root_uses_applies_offered_addin_to_closed_object() {
+    let schema = json!({
+        "$id": "https://example.com/order",
+        "$offers": { "Audited": "#/definitions/Audited" },
+        "type": "object",
+        "properties": { "id": { "type": "string" } },
+        "required": ["id"],
+        "additionalProperties": false,
+        "definitions": {
+            "Audited": {
+                "abstract": true,
+                "type": "object",
+                "properties": { "auditId": { "type": "string" } },
+                "required": ["auditId"]
+            }
+        }
+    });
+    let validator = InstanceValidator::new();
+
+    let valid = validator.validate(
+        r#"{"$schema":"https://example.com/order","$uses":["Audited"],"id":"1","auditId":"a1"}"#,
+        &schema,
+    );
+    assert!(valid.is_valid(), "Selected add-in must augment the closed root schema");
+
+    let not_selected = validator.validate(
+        r#"{"$schema":"https://example.com/order","id":"1","auditId":"a1"}"#,
+        &schema,
+    );
+    assert!(!not_selected.is_valid(), "Add-in properties require explicit selection");
+
+    let unknown = validator.validate(
+        r#"{"$schema":"https://example.com/order","$uses":["Unknown"],"id":"1"}"#,
+        &schema,
+    );
+    assert!(!unknown.is_valid(), "Unknown add-ins must be rejected");
+
+    let malformed = validator.validate(
+        r#"{"$schema":"https://example.com/order","$uses":"Audited","id":"1"}"#,
+        &schema,
+    );
+    assert!(!malformed.is_valid(), "$uses must be an array");
+}
 
 #[test]
 fn test_extends_simple() {

--- a/rust/tests/schema_validator_tests.rs
+++ b/rust/tests/schema_validator_tests.rs
@@ -92,6 +92,7 @@ fn test_valid_extends_schema() {
         "definitions": {
             "BaseType": {
                 "name": "BaseType",
+                "abstract": true,
                 "type": "object",
                 "properties": {
                     "baseProp": {"type": "string"}
@@ -134,7 +135,6 @@ fn test_valid_choice_schema() {
         "$id": "https://example.com/schema/choice",
         "name": "PaymentMethod",
         "type": "choice",
-        "selector": "type",
         "choices": {
             "card": {"type": "object", "properties": {"cardNumber": {"type": "string"}}},
             "cash": {"type": "object", "properties": {"amount": {"type": "decimal"}}}
@@ -604,10 +604,28 @@ fn test_choice_uses_choices_and_selector() {
         "$id": "https://example.com/schema/choice",
         "name": "ValidChoice",
         "type": "choice",
+        "$extends": "#/definitions/Base",
         "selector": "kind",
+        "definitions": {
+            "Base": {
+                "abstract": true,
+                "type": "object",
+                "properties": { "id": { "type": "string" } }
+            },
+            "OptionA": {
+                "type": "object",
+                "$extends": "#/definitions/Base",
+                "properties": { "a": { "type": "string" } }
+            },
+            "OptionB": {
+                "type": "object",
+                "$extends": "#/definitions/Base",
+                "properties": { "b": { "type": "int32" } }
+            }
+        },
         "choices": {
-            "optionA": {"type": "object", "properties": {"a": {"type": "string"}}},
-            "optionB": {"type": "object", "properties": {"b": {"type": "int32"}}}
+            "optionA": { "type": { "$ref": "#/definitions/OptionA" } },
+            "optionB": { "type": { "$ref": "#/definitions/OptionB" } }
         }
     }"##;
     let validator = SchemaValidator::new();
@@ -764,13 +782,65 @@ fn test_valid_offers_extension() {
     let schema = r##"{
         "$schema": "https://json-structure.org/meta/core/v0/#",
         "$id": "https://example.com/schema/offers",
-        "name": "OffersSchema",
-        "type": "string",
-        "$offers": ["JSONStructureUnits"]
+        "$root": "#/definitions/Root",
+        "$offers": { "Audited": "#/definitions/Audited" },
+        "definitions": {
+            "Root": {
+                "name": "Root",
+                "type": "object",
+                "properties": { "id": { "type": "string" } }
+            },
+            "Audited": {
+                "abstract": true,
+                "type": "object",
+                "properties": { "auditId": { "type": "string" } }
+            }
+        }
     }"##;
     let validator = SchemaValidator::new();
     let result = validator.validate(schema);
     assert!(result.is_valid(), "$offers extension should be valid");
+}
+
+#[test]
+fn test_invalid_inline_choice_alternative_without_common_base() {
+    let schema = r##"{
+        "$id": "https://example.com/schema/invalid-choice",
+        "name": "InvalidChoice",
+        "type": "choice",
+        "$extends": "#/definitions/Base",
+        "selector": "kind",
+        "definitions": {
+            "Base": {
+                "abstract": true,
+                "type": "object",
+                "properties": { "id": { "type": "string" } }
+            }
+        },
+        "choices": {
+            "optionA": { "type": "object", "properties": { "a": { "type": "string" } } }
+        }
+    }"##;
+    let result = SchemaValidator::new().validate(schema);
+    assert!(!result.is_valid(), "Inline alternatives must extend the common base");
+}
+
+#[test]
+fn test_invalid_abstract_type_with_additional_properties() {
+    let schema = r##"{
+        "$id": "https://example.com/schema/abstract",
+        "$root": "#/definitions/Base",
+        "definitions": {
+            "Base": {
+                "abstract": true,
+                "type": "object",
+                "properties": { "id": { "type": "string" } },
+                "additionalProperties": false
+            }
+        }
+    }"##;
+    let result = SchemaValidator::new().validate(schema);
+    assert!(!result.is_valid(), "Abstract types must not declare additionalProperties");
 }
 
 // =============================================================================

--- a/rust/tests/test_assets_tests.rs
+++ b/rust/tests/test_assets_tests.rs
@@ -347,8 +347,6 @@ fn prepare_instance_for_validation(instance: &Value, schema: &Value) -> Value {
         obj.remove("_description");
         obj.remove("_expectedError");
         obj.remove("_expectedValid");
-        // $schema is a meta-annotation, not instance data
-        obj.remove("$schema");
     }
 
     // Check if schema expects a primitive/array type and instance has { value: ... } wrapper


### PR DESCRIPTION
## Summary

- validate root `$schema` metadata and apply root `$uses` add-ins without mutating input
- implement inline-choice selection through `$extends` with constrained selector injection
- enforce abstract, `$extends`, `$offers`, and inline-choice schema rules
- release `jstruct` as `0.8.1` and verify tag/package/binary version agreement in CI
- stop the Rust shared-asset harness from stripping `$schema`

## Validation

- `cargo test --manifest-path rust/Cargo.toml --all-features`
- `jstruct --version` reports `jstruct 0.8.1`

## Issues

Closes #185
Closes #186
Closes #187
Closes #188
Closes #189

Normative follow-up: json-structure/core#34, json-structure/core#35, json-structure/core#36.

Sample prerequisite: json-structure/primer-and-samples#11.